### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,3 +500,8 @@ MIT License - Copyright (c) 2026 Lasha Efremidze
 **Made with ❤️ for the Swift community**
 
 [⭐ Star this repo](https://github.com/efremidze/swift-patterns-mcp) • [🐛 Report Bug](https://github.com/efremidze/swift-patterns-mcp/issues) • [✨ Request Feature](https://github.com/efremidze/swift-patterns-mcp/issues)
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/efremidze-swift-patterns-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/efremidze-swift-patterns-mcp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Hosted deployment" section to documentation detailing the availability of a hosted deployment option via Frontier AI, including a direct link to access the endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->